### PR TITLE
Support node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - 6
   - 8
+  - 10
 
 sudo: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 ## changelog
 
+## Unreleased
+
+- Node 10 support
+- Swaps request with needle
+
 ## 2.1.1
 
-- Update agentkeepalive dependency to v4.0.2. This will prevent this._evictSession error
+- Update agentkeepalive dependency to v4.0.2. This will prevent this._evictSession error_
 
 ## 2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 ## changelog
 
-## Unreleased
+## 3.0.0
 
 - Node 10 support
-- Swaps request with needle
+- Swaps request with needle (may cause breaking changes if you use a custom client to customize request options)
+- Uses agentkeepalive for all requests
 
 ## 2.1.1
 
-- Update agentkeepalive dependency to v4.0.2. This will prevent this._evictSession error_
+- Update agentkeepalive dependency to v4.0.2. This will prevent this. _evictSession error_
 
 ## 2.1.0
 

--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ Transform GeoJSON into Mapnik XML.
 
 ### url markers
 
-If your GeoJSON object has one or more features with a `marker-url` property, `mapnikify()` will write the images found at the url into a file in a temporary directory and use that path in the Mapnik XML. This uses the [request library](https://www.npmjs.com/package/request) to handle the http file fetching.
+If your GeoJSON object has one or more features with a `marker-url` property, `mapnikify()` will write the images found at the url into a file in a temporary directory and use that path in the Mapnik XML. This uses the [needle library](https://www.npmjs.com/package/needle) to handle the http file fetching.
 
 By default the request will attempt to fetch binary data from the specified url. If the url is `http` and not `https` , Mapnikify will use [agentkeepalive](https://www.npmjs.com/package/agentkeepalive) to speed up requesting multiple images. There is also a default timeout of 5 seconds.
 
-You can customize the defaults passed to `request()` . Simply set a custom wrapper defined with `request.defaults` . See [request's documentation on defaults](https://www.npmjs.com/package/request#requestdefaultsoptions) for more information. For a quick example, this will set a longer timeout:
+You can customize the defaults passed to `needle()` . Simply set a custom wrapper defined with `needle.defaults` . See [needle's documentation on defaults](https://www.npmjs.com/package/needle#overriding-defaults) for more information. For a quick example, this will set a longer timeout:
 
 ```javascript
 var mapnikify = require('mapnikify');
-var myRequest = require('request').defaults({
+var myRequest = require('needle').defaults({
   timeout: 10000,
   followRedirect: false
 });

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Transform GeoJSON into Mapnik XML.
 
 If your GeoJSON object has one or more features with a `marker-url` property, `mapnikify()` will write the images found at the url into a file in a temporary directory and use that path in the Mapnik XML. This uses the [needle library](https://www.npmjs.com/package/needle) to handle the http file fetching.
 
-By default the request will attempt to fetch binary data from the specified url. If the url is `http` and not `https` , Mapnikify will use [agentkeepalive](https://www.npmjs.com/package/agentkeepalive) to speed up requesting multiple images. There is also a default timeout of 5 seconds.
+By default the request will attempt to fetch binary data from the specified url. Mapnikify will use [agentkeepalive](https://www.npmjs.com/package/agentkeepalive) to speed up requesting multiple images. There is also a default timeout of 5 seconds.
 
 You can customize the defaults passed to `needle()` . Simply set a custom wrapper defined with `needle.defaults` . See [needle's documentation on defaults](https://www.npmjs.com/package/needle#overriding-defaults) for more information. For a quick example, this will set a longer timeout:
 

--- a/lib/get.js
+++ b/lib/get.js
@@ -1,4 +1,4 @@
-var AgentKeepAlive = require('agentkeepalive'),
+var AgentKeepAlive = require('agentkeepalive').HttpsAgent,
     xtend = require('xtend'),
     needle = require('needle');
 
@@ -24,7 +24,7 @@ module.exports = function get(options, callback) {
 
     // This might load the same file multiple times, but the overhead should
     // be very little.
-    request.get(options, function(err, resp, data) {
+    request.get(options, { agent: agent }, function(err, resp, data) {
         // Use err.status of 400 as it's not an unexpected application error,
         // but likely due to a bad request. Catches ECONNREFUSED,
         // getaddrinfo ENOENT, etc.
@@ -64,6 +64,10 @@ function normalizeParams(options) {
 
 // allows passing in a custom request handler
 function getClientSettings() {
-  module.exports.requestClient ? module.exports.requestClient : needle.defaults({ response_timeout: 4000 });
+  module.exports.requestClient ?
+    module.exports.requestClient :
+    needle.defaults({
+      response_timeout: 4000
+    });
   return needle;
 }

--- a/lib/get.js
+++ b/lib/get.js
@@ -6,7 +6,6 @@ var AgentKeepAlive = require('agentkeepalive').HttpsAgent,
 // host can use keep-alive for performance.
 var agent = new AgentKeepAlive({
     maxSockets: 128,
-    maxKeepAliveRequests: 0,
     freeSocketTimeout: 30000
 });
 
@@ -33,8 +32,6 @@ module.exports = function get(options, callback) {
             reqErr.originalError = err;
             return callback(reqErr);
         }
-        // request 2.2.x *always* returns the response body as a string.
-        // @TODO remove this once request is upgraded.
         if (!(data instanceof Buffer)) data = new Buffer.from(data, 'binary');
         // Restrict data length.
         if (data.length > 32768) return callback(new Error('Marker loaded from URL is too large.'));
@@ -62,7 +59,7 @@ function normalizeParams(options) {
     return params;
 }
 
-// allows passing in a custom request handler
+// allows passing in a custom request handler for needle
 function getClientSettings() {
   module.exports.requestClient ?
     module.exports.requestClient :

--- a/lib/get.js
+++ b/lib/get.js
@@ -35,7 +35,7 @@ module.exports = function get(options, callback) {
         }
         // request 2.2.x *always* returns the response body as a string.
         // @TODO remove this once request is upgraded.
-        if (!(data instanceof Buffer)) data = new Buffer(data, 'binary');
+        if (!(data instanceof Buffer)) data = new Buffer.from(data, 'binary');
         // Restrict data length.
         if (data.length > 32768) return callback(new Error('Marker loaded from URL is too large.'));
         callback(null, data);

--- a/lib/get.js
+++ b/lib/get.js
@@ -1,6 +1,6 @@
 var AgentKeepAlive = require('agentkeepalive'),
     xtend = require('xtend'),
-    requestLib = require('request');
+    needle = require('needle');
 
 // Use a single agent for all requests so that requests to the same
 // host can use keep-alive for performance.
@@ -18,13 +18,13 @@ var agent = new AgentKeepAlive({
  * @param {function} callback
  */
 module.exports = function get(options, callback) {
-    var request = getClient();
+    var request = getClientSettings();
     var params = normalizeParams(options);
     if(!params) { callback(new Error('Invalid parameters: ' + JSON.stringify(options))); }
 
     // This might load the same file multiple times, but the overhead should
     // be very little.
-    request(params, function(err, resp, data) {
+    request.get(options, function(err, resp, data) {
         // Use err.status of 400 as it's not an unexpected application error,
         // but likely due to a bad request. Catches ECONNREFUSED,
         // getaddrinfo ENOENT, etc.
@@ -63,13 +63,7 @@ function normalizeParams(options) {
 }
 
 // allows passing in a custom request handler
-function getClient() {
-    if (module.exports.requestClient) { return module.exports.requestClient; }
-    return requestLib.defaults({
-        timeout: 5000,
-        encoding: 'binary',
-        headers: {
-            'accept-encoding': 'binary'
-        }
-    });
+function getClientSettings() {
+  module.exports.requestClient ? module.exports.requestClient : needle.defaults({ response_timeout: 4000 });
+  return needle;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,8 @@
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
     },
     "aproba": {
       "version": "1.2.0",
@@ -109,6 +110,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -116,7 +118,8 @@
     "assert-plus": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "dev": true
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -133,17 +136,20 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "aws-sign2": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "dev": true
     },
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -154,6 +160,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -162,6 +169,7 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -178,7 +186,8 @@
     "caseless": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+      "dev": true
     },
     "chai": {
       "version": "4.2.0",
@@ -198,6 +207,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
       "requires": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -226,6 +236,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -233,7 +244,8 @@
     "commander": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -303,6 +315,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true,
       "requires": {
         "boom": "2.x.x"
       }
@@ -311,6 +324,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       },
@@ -318,16 +332,24 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
         }
       }
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "deep-eql": {
@@ -365,7 +387,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -386,6 +409,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -399,7 +423,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.7.1",
@@ -443,12 +468,14 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "1.0.7",
@@ -493,12 +520,14 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "form-data": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.5",
@@ -537,6 +566,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
       "requires": {
         "is-property": "^1.0.2"
       }
@@ -545,6 +575,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
       "requires": {
         "is-property": "^1.0.0"
       }
@@ -559,6 +590,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       },
@@ -566,7 +598,8 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
         }
       }
     },
@@ -627,6 +660,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+      "dev": true,
       "requires": {
         "chalk": "^1.1.1",
         "commander": "^2.9.0",
@@ -644,6 +678,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -663,6 +698,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "dev": true,
       "requires": {
         "boom": "2.x.x",
         "cryptiles": "2.x.x",
@@ -673,12 +709,14 @@
     "hoek": {
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "dev": true
     },
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "dev": true,
       "requires": {
         "assert-plus": "^0.2.0",
         "jsprim": "^1.2.2",
@@ -739,12 +777,14 @@
     "is-my-ip-valid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "dev": true
     },
     "is-my-json-valid": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
       "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
+      "dev": true,
       "requires": {
         "generate-function": "^2.0.0",
         "generate-object-property": "^1.1.0",
@@ -756,12 +796,14 @@
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -777,7 +819,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "istanbul": {
       "version": "0.3.22",
@@ -846,27 +889,32 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "jsonpointer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -877,7 +925,8 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
         }
       }
     },
@@ -938,12 +987,14 @@
     "mime-db": {
       "version": "1.38.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
+      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.22",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
       "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+      "dev": true,
       "requires": {
         "mime-db": "~1.38.0"
       }
@@ -1010,11 +1061,11 @@
       "dev": true
     },
     "needle": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
-      "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
       "requires": {
-        "debug": "^2.1.2",
+        "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
         "sax": "^1.2.4"
       }
@@ -1082,11 +1133,6 @@
         "tar": "^4"
       }
     },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-    },
     "nopt": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
@@ -1129,7 +1175,8 @@
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -1229,12 +1276,14 @@
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
       }
@@ -1259,12 +1308,14 @@
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
     },
     "qs": {
       "version": "6.3.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
+      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+      "dev": true
     },
     "queue-async": {
       "version": "1.0.7",
@@ -1294,33 +1345,6 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
-      }
-    },
-    "request": {
-      "version": "2.78.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.78.0.tgz",
-      "integrity": "sha1-4cjew0bhyBkjskrNszfxHeyr6cw=",
-      "requires": {
-        "aws-sign2": "~0.6.0",
-        "aws4": "^1.2.1",
-        "caseless": "~0.11.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.0",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.1.1",
-        "har-validator": "~2.0.6",
-        "hawk": "~3.1.3",
-        "http-signature": "~1.1.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.7",
-        "node-uuid": "~1.4.7",
-        "oauth-sign": "~0.8.1",
-        "qs": "~6.3.0",
-        "stringstream": "~0.0.4",
-        "tough-cookie": "~2.3.0",
-        "tunnel-agent": "~0.4.1"
       }
     },
     "resolve": {
@@ -1400,6 +1424,7 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -1424,6 +1449,7 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -1439,7 +1465,8 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
         }
       }
     },
@@ -1464,7 +1491,8 @@
     "stringstream": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
+      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -1482,7 +1510,8 @@
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
     },
     "tape": {
       "version": "2.14.1",
@@ -1552,6 +1581,7 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "dev": true,
       "requires": {
         "punycode": "^1.4.1"
       }
@@ -1559,12 +1589,14 @@
     "tunnel-agent": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+      "dev": true
     },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -1617,6 +1649,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -1626,7 +1659,8 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "@mapbox/makizushi": "^3.0.1",
     "agentkeepalive": "^4.0.2",
     "minimist": "~1.2.0",
+    "needle": "^2.4.0",
     "queue-async": "~1.0.7",
-    "request": "~2.78.0",
     "sigmund": "~1.0.0",
     "xtend": "~4.0.0"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -7,7 +7,7 @@ var test = require('tape'),
     mapnik = require('mapnik'),
     cachepath = require('../lib/cachepath.js'),
     urlmarker = require('../lib/urlmarker.js'),
-    request = require('request'),
+    needle = require('needle'),
     generatexml = require('../');
 
 mapnik.register_default_input_plugins();
@@ -142,7 +142,7 @@ test('urlmarker-jpg', function(t) {
 });
 
 test('urlmarker-custom-client', function(t) {
-    var client = request.defaults({ timeout: 100, encoding: 'binary' });
+    var client = needle.defaults({ response_timeout: 100 });
     var file = fs.readFileSync(path.resolve(__dirname, 'data', 'rocket.png'));
     var scope = nock('http://devnull.mapnik.org')
         .get(/.*/)
@@ -156,7 +156,7 @@ test('urlmarker-custom-client', function(t) {
         }
     }, function(err, res) {
             t.equal(err.message, 'Unable to load marker from URL.');
-            t.equal(err.originalError.code, 'ESOCKETTIMEDOUT');
+            t.equal(err.originalError.code, 'ECONNRESET');
             generatexml.setRequestClient(null);
             nock.cleanAll();
             t.end();
@@ -164,7 +164,7 @@ test('urlmarker-custom-client', function(t) {
 });
 
 test('urlmarker-too-large-custom-client', function(t) {
-    var client = request.defaults({ timeout: 100, encoding: 'binary' });
+    var client = needle.defaults({ timeout: 100 });
     var file = fs.readFileSync(path.resolve(__dirname, 'data', 'html-page.png'));
     var scope = nock('http://devnull.mapnik.org')
         .get(/.*/)

--- a/test/test.js
+++ b/test/test.js
@@ -164,7 +164,7 @@ test('urlmarker-custom-client', function(t) {
 });
 
 test('urlmarker-too-large-custom-client', function(t) {
-    var client = needle.defaults({ timeout: 100 });
+    var client = needle.defaults({ response_timeout: 100 });
     var file = fs.readFileSync(path.resolve(__dirname, 'data', 'html-page.png'));
     var scope = nock('http://devnull.mapnik.org')
         .get(/.*/)

--- a/test/test.js
+++ b/test/test.js
@@ -186,7 +186,7 @@ test('urlmarker-too-large-custom-client', function(t) {
 // ensure generatexml.setRequestClient(null) returns to default client
 test('urlmarker-uncustomize-client', function(t) {
     var file = fs.readFileSync(path.resolve(__dirname, 'data', 'rocket.png'));
-    var scope = nock('http://devnull.mapnik.org', { reqheaders: {'accept-encoding': 'binary'}})
+    var scope = nock('http://devnull.mapnik.org')
         .get(/.*/)
         .delay(300)
         .reply(200, file, { 'content-type': 'image/png' });


### PR DESCRIPTION
Since node 8 is EOL'ing, we should upgrade to node 10.

This upgrade includes:
- swapping request with needle (which have different default options than request... check em out https://www.npmjs.com/package/needle#request-options)
- configuring the agent to use https
- updating deprecated `Buffer` method to use `Buffer.from()`

We are switching to needle since request doesn't seem to respect timeout options with node 10.

Configuring the request client should work the same as it did previously, but you'll need to use the appropriate options for needle (eg `encoding` is no longer a valid option).

cc @springmeyer @ian29 @riastrad 