### PR TITLE
Allow one redirect by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## changelog
 
+## 3.0.1
+- Configures agent to use http or https depending on request
+- Allows up to one redirect for requests by default
+
 ## 3.0.0
 
 - Node 10 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## changelog
 
 ## 3.0.1
-- Configures agent to use http or https depending on request
 - Allows up to one redirect for requests by default
 
 ## 3.0.0

--- a/lib/get.js
+++ b/lib/get.js
@@ -1,14 +1,17 @@
-var AgentKeepAlive = require('agentkeepalive').HttpsAgent,
+var AgentKeepAlive = require('agentkeepalive'),
     xtend = require('xtend'),
     needle = require('needle');
 
 // Use a single agent for all requests so that requests to the same
 // host can use keep-alive for performance.
-var agent = new AgentKeepAlive({
-    maxSockets: 128,
-    freeSocketTimeout: 30000
-});
-
+function agent(url) {
+  var opts = { maxSockets: 128, freeSocketTimeout: 30000 };
+  if (/^http:/.test(url)) {
+    return new AgentKeepAlive(opts);
+  } else {
+    return new AgentKeepAlive(opts).HttpsAgent;
+  }
+}
 /**
  * Safely get a file at a uri as a binary buffer, with timeout protection
  * and a length limit.
@@ -23,7 +26,7 @@ module.exports = function get(options, callback) {
 
     // This might load the same file multiple times, but the overhead should
     // be very little.
-    request.get(options, { agent: agent }, function(err, resp, data) {
+    request.get(options, { agent: agent(options) }, function(err, resp, data) {
         // Use err.status of 400 as it's not an unexpected application error,
         // but likely due to a bad request. Catches ECONNREFUSED,
         // getaddrinfo ENOENT, etc.

--- a/lib/get.js
+++ b/lib/get.js
@@ -1,13 +1,13 @@
-var AgentKeepAlive = require('agentkeepalive').HttpsAgent,
+var AgentKeepAlive = require('agentkeepalive'),
     xtend = require('xtend'),
     needle = require('needle');
 
 // Use a single agent for all requests so that requests to the same
 // host can use keep-alive for performance.
-var agent = new AgentKeepAlive({
-    maxSockets: 128,
-    freeSocketTimeout: 30000
-});
+var opts = { maxSockets: 128, freeSocketTimeout: 30000 }
+var httpAgent = new AgentKeepAlive(opts);
+var httpsAgent = new AgentKeepAlive(opts).httpAgent;
+var agent;
 
 /**
  * Safely get a file at a uri as a binary buffer, with timeout protection
@@ -23,6 +23,7 @@ module.exports = function get(options, callback) {
 
     // This might load the same file multiple times, but the overhead should
     // be very little.
+    agent = (/^http:/.test(options)) ? httpAgent : httpsAgent;
     request.get(options, { agent: agent }, function(err, resp, data) {
         // Use err.status of 400 as it's not an unexpected application error,
         // but likely due to a bad request. Catches ECONNREFUSED,

--- a/lib/get.js
+++ b/lib/get.js
@@ -67,7 +67,8 @@ function getClientSettings() {
   module.exports.requestClient ?
     module.exports.requestClient :
     needle.defaults({
-      response_timeout: 4000
+      response_timeout: 4000,
+      follow_max: 1
     });
   return needle;
 }

--- a/lib/get.js
+++ b/lib/get.js
@@ -1,17 +1,14 @@
-var AgentKeepAlive = require('agentkeepalive'),
+var AgentKeepAlive = require('agentkeepalive').HttpsAgent,
     xtend = require('xtend'),
     needle = require('needle');
 
 // Use a single agent for all requests so that requests to the same
 // host can use keep-alive for performance.
-function agent(url) {
-  var opts = { maxSockets: 128, freeSocketTimeout: 30000 };
-  if (/^http:/.test(url)) {
-    return new AgentKeepAlive(opts);
-  } else {
-    return new AgentKeepAlive(opts).HttpsAgent;
-  }
-}
+var agent = new AgentKeepAlive({
+    maxSockets: 128,
+    freeSocketTimeout: 30000
+});
+
 /**
  * Safely get a file at a uri as a binary buffer, with timeout protection
  * and a length limit.
@@ -26,7 +23,7 @@ module.exports = function get(options, callback) {
 
     // This might load the same file multiple times, but the overhead should
     // be very little.
-    request.get(options, { agent: agent(options) }, function(err, resp, data) {
+    request.get(options, { agent: agent }, function(err, resp, data) {
         // Use err.status of 400 as it's not an unexpected application error,
         // but likely due to a bad request. Catches ECONNREFUSED,
         // getaddrinfo ENOENT, etc.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/geojson-mapnikify",
-  "version": "3.0.1-dev.0",
+  "version": "3.0.1-dev.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/geojson-mapnikify",
-  "version": "3.0.0",
+  "version": "3.0.1-dev.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/geojson-mapnikify",
-  "version": "3.0.1-dev.0",
+  "version": "3.0.1-dev.1",
   "description": "transform geojson with simplestyle-spec into mapnik xml",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/geojson-mapnikify",
-  "version": "3.0.0",
+  "version": "3.0.1-dev.0",
   "description": "transform geojson with simplestyle-spec into mapnik xml",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
<s>We want to allow both http _and_ https for requests, so configure agent to do so</s>

This changes the request config to allow up to one redirect by default (in case the request url is shortened and needs to redirect). This can be customized by passing in a custom client config (see readme).